### PR TITLE
Use repo.from_path(...) interface

### DIFF
--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -72,7 +72,7 @@ def quick_clone_repos(prefix, args):
     repos = []
     for r in roots:
         try:
-            repos.append(spack.repo.Repo(r))
+            repos.append(spack.repo.from_path(r))
         except spack.repo.RepoError:
             continue
     for repo in repos:
@@ -81,7 +81,7 @@ def quick_clone_repos(prefix, args):
         if os.path.exists(f"{repo.root}/.git"):
             git("clone", "-q", "--depth", "2", f"file://{repo.root}", dest)
         elif not os.path.exists(dest):
-            # non-git repo, and not already there, symlink it? 
+            # non-git repo, and not already there, symlink it?
             os.symlink(repo.root, dest)
 
 
@@ -94,7 +94,7 @@ def quick_clone_ext(prefix, args):
             dest = f"{prefix}/var/spack/extensions/{base}"
             git("clone", "-q", "--depth", "2", f"file://{path}", dest)
         elif not os.path.exists(dest):
-            # non-git repo, and not already there, symlink it? 
+            # non-git repo, and not already there, symlink it?
             os.symlink(path, dest)
 
 
@@ -146,8 +146,8 @@ def clone_various_configs(prefix, args):
     # the -name arg is boot*.yaml pack*.yaml comp*.yaml interleaved..
     # sorry, some things are just easier in shell...
     os.system(
-        f""" 
-        cd $SPACK_ROOT && 
+        f"""
+        cd $SPACK_ROOT &&
         find etc/spack -name [pcm][aoi][cmnr][kfpr]*.yaml -print |
            cpio -dump {prefix}
     """


### PR DESCRIPTION
Fixes bug:

```console
knoepfel@scisoftbuild02 scratch $ spack -d subspack ~/scratch/spack-descendent
  ...
  File "/scratch/knoepfel/spack-primogenitor/lib/spack/spack/main.py", line 650, in _invoke_command
    return_val = command(parser, args)
  File "/scratch/knoepfel/spack-primogenitor/var/spack/extensions/spack-subspack/subspack/cmd/subspack.py", line 44, in subspack
    subspackext.make_subspack(args)
  File "/scratch/knoepfel/spack-primogenitor/var/spack/extensions/spack-subspack/subspack/subspack.py", line 27, in make_subspack
    quick_clone_repos(prefix, args)
  File "/scratch/knoepfel/spack-primogenitor/var/spack/extensions/spack-subspack/subspack/subspack.py", line 75, in quick_clone_repos
    repos.append(spack.repo.Repo(r))
TypeError: __init__() missing 1 required keyword-only argument: 'cache'
```