### PR TITLE
also clone include.yaml

### DIFF
--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -177,6 +177,11 @@ def clone_various_configs(prefix, args):
     """
     )
 
+    # also make sure there is an etc/spack/base directory
+    basedir = f"{prefix}/etc/spack/base"
+    if (not os.path.isdir(basedir) ):
+        os.mkdir( basedir )
+
     root = spack.config.get("bootstrap:root", default=None)
     if root:
         root = spack.util.path.canonicalize_path(root)

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -163,11 +163,11 @@ def clone_various_configs(prefix, args):
     # the -name arg is boot*.yaml pack*.yaml comp*.yaml interleaved..
     # sorry, some things are just easier in shell...
     if args.without_caches:
-        # interleaved pack/conf/comp
-        pattern="[pc][ao][cmn][kfp]*.yaml"
+        # interleaved pack/conf/comp/incl
+        pattern="[pci][aon][cmn][kfpl]*.yaml"
     else:
-        # interleaved pack/conf/comp/mirr
-        pattern="[pcm][aoi][cmnr][kfpr]*.yaml"
+        # interleaved pack/conf/comp/mirr/incl
+        pattern="[ipcm][aoin][cmnr][lkfpr]*.yaml"
 
     os.system(
         f"""


### PR DESCRIPTION
For Spack 1.0, we use a $SPACK_ROOT/etc/spack/include.yaml to include platform specific scope directories, 
spack subspack was not transferring that to the new instance.   So we add the "i" "n" "c" "l" into the interleaved
bracket pattern we use for copying config files, and that should now be better. 
