### PR TITLE
Add --local_bootstrap flag

### DIFF
--- a/subspack/cmd/subspack.py
+++ b/subspack/cmd/subspack.py
@@ -66,10 +66,10 @@ def setup_parser(subparser):
         help="update extension repositories from their upstreams' origins",
     )
     subparser.add_argument(
-        "--local-bootstrap",
+        "--upstream-bootstrap",
         action="store_true",
         default=False,
-        help="Do not share spack bootstrap area with upstream",
+        help="Share spack bootstrap area with upstream",
     )
 
 

--- a/subspack/cmd/subspack.py
+++ b/subspack/cmd/subspack.py
@@ -65,6 +65,12 @@ def setup_parser(subparser):
         default=False,
         help="update extension repositories from their upstreams' origins",
     )
+    subparser.add_argument(
+        "--local-bootstrap",
+        action="store_true",
+        default=False,
+        help="Do not share spack bootstrap area with upstream",
+    )
 
 
 def subspack(parser, args):

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,7 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            if isinstance(roots[repo_name], dict):
+            if "branch" in roots[repo_name]:
                 branch = roots[repo_name].get("branch", "main")
             else:
                 branch = "main"

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,7 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            branch = roots[repo_name]["branch"]
+            branch = roots[repo_name].get("branch", "main")
             base = repo_name
             if isinstance(roots[repo_name], dict):
                 dest = roots[repo_name]["destination"]

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -325,11 +325,11 @@ def clone_various_configs(prefix, args):
         os.mkdir(basedir)
 
     if args.local_bootstrap:
+        root = f"{prefix}/var/spack/.bootstrap"
+    else:
         root = spack.config.get("bootstrap:root", default=None)
         if root:
             root = spack.util.path.canonicalize_path(root)
-    else:
-        root = f"{prefix}/var/spack/.bootstrap"
 
     with tmp_env("SPACK_ROOT", prefix):
         os.system(f"{prefix}/bin/spack bootstrap root {root} > /dev/null")

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -303,9 +303,12 @@ def clone_various_configs(prefix, args):
     if not os.path.isdir(basedir):
         os.mkdir(basedir)
 
-    root = spack.config.get("bootstrap:root", default=None)
-    if root:
-        root = spack.util.path.canonicalize_path(root)
+    if args.local_bootstrap:
+        root = spack.config.get("bootstrap:root", default=None)
+        if root:
+            root = spack.util.path.canonicalize_path(root)
+    else:
+        root = f"{prefix}/var/spack/.bootstrap"
 
     with tmp_env("SPACK_ROOT", prefix):
         os.system(f"{prefix}/bin/spack bootstrap root {root} > /dev/null")

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,10 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            branch = roots[repo_name].get("branch", "main")
+            if isinstance(roogs[repo_name], dict):
+                branch = roots[repo_name].get("branch", "main")
+            else:
+                branch = "main"
             base = repo_name
             if isinstance(roots[repo_name], dict):
                 dest = roots[repo_name]["destination"]

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,7 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            if isinstance(roogs[repo_name], dict):
+            if isinstance(roots[repo_name], dict):
                 branch = roots[repo_name].get("branch", "main")
             else:
                 branch = "main"

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -324,12 +324,11 @@ def clone_various_configs(prefix, args):
     if not os.path.isdir(basedir):
         os.mkdir(basedir)
 
-    if args.local_bootstrap:
-        root = f"{prefix}/var/spack/.bootstrap"
-    else:
-        root = spack.config.get("bootstrap:root", default=None)
-        if root:
-            root = spack.util.path.canonicalize_path(root)
+    root = f"{prefix}/var/spack/.bootstrap"
+    if args.upstream_bootstrap:
+        uroot = spack.config.get("bootstrap:root", default=None)
+        if uroot:
+            root = spack.util.path.canonicalize_path(uroot)
 
     with tmp_env("SPACK_ROOT", prefix):
         os.system(f"{prefix}/bin/spack bootstrap root {root} > /dev/null")

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -198,6 +198,8 @@ def quick_clone_repos(prefix, args):
 
             else:
                 tty.debug(f"symlinking {src} to {dest}")
+                if not os.path.exists(os.path.dirname(dest)):
+                     os.makedirs(os.path.dirname(dest))
                 # non-git repo, and not already there, symlink it?
                 os.symlink(src, dest)
     else:


### PR DESCRIPTION

Sometimes you want to do a subspack on a system that has different externals, and you need a local bootstrap area.
This option  will make spack subspack not share a bootstrap area with the upstream. 