### PR TITLE
Upstream remote branch naming for repositories, etc.

### DIFF
--- a/subspack/cmd/subspack.py
+++ b/subspack/cmd/subspack.py
@@ -65,6 +65,12 @@ def setup_parser(subparser):
         default=False,
         help="update extension repositories from their upstreams' origins",
     )
+    subparser.add_argument(
+        "--local-bootstrap",
+        action="store_true",
+        default=False,
+        help="Do not share spack bootstrap area with upstream",
+    )
 
 
 def subspack(parser, args):

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,7 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            if isinstance(roots[repo_name], dict):
+            if "branch" in roots[repo_name]:
                 branch = roots[repo_name].get("branch", "main")
             else:
                 branch = "main"

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,7 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            branch = roots[repo_name]["branch"]
+            branch = roots[repo_name].get("branch", "main")
             base = repo_name
             if isinstance(roots[repo_name], dict):
                 dest = roots[repo_name]["destination"]

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -325,11 +325,11 @@ def clone_various_configs(prefix, args):
         os.mkdir(basedir)
 
     if args.local_bootstrap:
+        root = f"{prefix}/var/spack/.bootstrap"
+    else:
         root = spack.config.get("bootstrap:root", default=None)
         if root:
             root = spack.util.path.canonicalize_path(root)
-    else:
-        root = f"{prefix}/var/spack/.bootstrap"
 
     with tmp_env("SPACK_ROOT", prefix):
         os.system(f"{prefix}/bin/spack bootstrap root {root} > /dev/null")

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -50,7 +50,7 @@ def make_subspack(args):
 
 
 def add_upstream_origin(src, dest):
-    """if the upstream repository at src has an "origin", add it to the repostory at dest as "upstream_origin" """
+    """if the upstream repository at src has an "origin", add it to the repostory and make the current origin "upstream" """
     path = None
     git = spack.util.git.git(required=True)
     with fs.working_dir(src):
@@ -61,7 +61,8 @@ def add_upstream_origin(src, dest):
                     break
     if path:
         with fs.working_dir(dest):
-            git("remote", "add", "upstream_origin", path)
+            git("remote", "rename", "origin", "upstream")
+            git("remote", "add", "origin", path)
     return path
 
 

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -303,9 +303,12 @@ def clone_various_configs(prefix, args):
     if not os.path.isdir(basedir):
         os.mkdir(basedir)
 
-    root = spack.config.get("bootstrap:root", default=None)
-    if root:
-        root = spack.util.path.canonicalize_path(root)
+    if args.local_bootstrap:
+        root = spack.config.get("bootstrap:root", default=None)
+        if root:
+            root = spack.util.path.canonicalize_path(root)
+    else:
+        root = f"{prefix}/var/spack/.bootstrap"
 
     with tmp_env("SPACK_ROOT", prefix):
         os.system(f"{prefix}/bin/spack bootstrap root {root} > /dev/null")

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,10 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            branch = roots[repo_name].get("branch", "main")
+            if isinstance(roogs[repo_name], dict):
+                branch = roots[repo_name].get("branch", "main")
+            else:
+                branch = "main"
             base = repo_name
             if isinstance(roots[repo_name], dict):
                 dest = roots[repo_name]["destination"]

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -159,7 +159,7 @@ def quick_clone_repos(prefix, args):
         for repo_name in roots:
             tty.debug(f"repo {repo_name}")
             tty.debug(f"roots[repo_name] is {repr(roots[repo_name])}")
-            if isinstance(roogs[repo_name], dict):
+            if isinstance(roots[repo_name], dict):
                 branch = roots[repo_name].get("branch", "main")
             else:
                 branch = "main"

--- a/subspack/subspack.py
+++ b/subspack/subspack.py
@@ -198,6 +198,8 @@ def quick_clone_repos(prefix, args):
 
             else:
                 tty.debug(f"symlinking {src} to {dest}")
+                if not os.path.exists(os.path.dirname(dest)):
+                     os.makedirs(os.path.dirname(dest))
                 # non-git repo, and not already there, symlink it?
                 os.symlink(src, dest)
     else:


### PR DESCRIPTION
The  previous naming of the repository remotes was unhelpful when folks wanted to update recipe repositories; 
the copy in the upstream instance was listed as "origin" its "origin" remote was addes as "upstream_origin".
Now we set our origin to the same as the upstream's and make the reference to the upstreams copy named "upstream" . 